### PR TITLE
bumped version in project and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 
 julia:
-  - 0.7
+  - 1.0
   - nightly
 
 matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LambertW"
 desc = "Lambert W function and associated omega constant"
 authors = ["J Lapeyre"]
-version = "0.4.3"
+version = "0.4.5"
 license = "MIT"
 uuid = "984bce1d-4616-540c-a9ee-88d1112d94c9"
 


### PR DESCRIPTION
Currently the last tagged version (0.4.4) is inconsistent with the one in Project.toml (0.4.3). Closes #17 
I bumped the version in Project.toml to 0.4.5, and also bumped the travis-ci script to test on julia v1.0 (and nightly) instead of v0.7.

After merging this one, assuming JuliaRegistrator and TagBot are configured for this github repo, please add the JuliaRegistrator register comment to the last commit.