### PR TITLE
added compat to project.toml to fix #19

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,15 @@
 name = "LambertW"
+uuid = "984bce1d-4616-540c-a9ee-88d1112d94c9"
+license = "MIT"
 desc = "Lambert W function and associated omega constant"
 authors = ["J Lapeyre"]
 version = "0.4.5"
-license = "MIT"
-uuid = "984bce1d-4616-540c-a9ee-88d1112d94c9"
 
-[deps]
+[compat]
+julia = "1"
+
+[extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]


### PR DESCRIPTION
I know it's a bit confusing first time you use registrator. Hard to get right the first time.
Currently, the registry [PR](https://github.com/JuliaRegistries/General/pull/8597) is still alive just not auto merging because it skips a version (which I think it should), but also because I forgot to add something like the following to the Project.toml
```
[compat]
julia = "1"
```
This PR corrects that. After merging, my favorite way to trigger registrator is to click on the last commit in github and add a comment with the magic words for registrator. I think if you do that before the registry PR gets merged, it should just update it automatically.
It may still need a manual merging, but at least this package will finally work with the new registry as desired when that is done.
Thanks!