### PR TITLE
Fix over exact test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1
   - julia_version: nightly
 

--- a/test/lambertw_test.jl
+++ b/test/lambertw_test.jl
@@ -55,7 +55,7 @@ end
 # The routine will start at -1/e + eps * im, rather than -1/e + 0im,
 # otherwise root finding will fail
 if Int != Int32
-    @test abs(lambertw(-1.0/MathConstants.e  + 0im, -1)) == 1
+    @test isapprox(abs(lambertw(-1.0/MathConstants.e  + 0im, -1)), 1; atol=1e-15)
 else
     @test abs(lambertw(-1.0/MathConstants.e  + 0im, -1) + 1) < 1e-7
 end


### PR DESCRIPTION
A test for a result `== 1` fails for recent versions. We now use `isexact` with `atol=1e-15`. The error looks like an ulp.
