### PR TITLE
Define method for `AbstractIrrational` instead of `Irrational`

### DIFF
--- a/src/LambertW.jl
+++ b/src/LambertW.jl
@@ -78,7 +78,7 @@ function _lambertw(::typeof(MathConstants.e), k, maxits)
     k == 0 && return 1
     throw(DomainError(k))
 end
-_lambertw(x::Irrational, k, maxits) = _lambertw(float(x), k, maxits)
+_lambertw(x::AbstractIrrational, k, maxits) = _lambertw(float(x), k, maxits)
 function _lambertw(x::Union{Integer, Rational}, k, maxits)
     if k == 0
         x == 0 && return float(zero(x))


### PR DESCRIPTION
I was looking at usage of Irrational in packages (https://juliahub.com/ui/Search?q=Irrational&type=symbols&u=use&t=type), to estimate how breaking https://github.com/JuliaMath/IrrationalConstants.jl/pull/19 (motivated by https://github.com/JuliaLang/julia/issues/46531) will be. LambertW showed up in the list of packages but `_lambertw` can be defined for `AbstractIrrational` instead of `Irrational` without breaking anything.

Note that this PR does not address the main issue regarding the use of `Base.@irrational` and definition of `Irrational`s, as explained in https://github.com/JuliaLang/julia/issues/46531.